### PR TITLE
Use performance.now() for timing

### DIFF
--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -58,7 +58,7 @@ function loop() {
     requestAnimFrame(loop);
     return;
   }
-  t = +new Date();
+  t = performance.now();
   dt += (t - old_time);
   old_time = t;
   songTime = mm.music.currentTime;
@@ -97,7 +97,7 @@ function bootstrap() {
   dt = 0;
   tick = 0;
   t = 0;
-  time = +new Date();
+  time = performance.now();
   old_time = time;
   KEYS = [];
   for (var i = 0; i < 256; i++) {


### PR DESCRIPTION
performance.now() has much better browser support, so we can use it for
faster and more accurate timings.
