### PR TITLE
Update time variables in the loading loop

### DIFF
--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -56,6 +56,7 @@ function loop() {
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.fillStyle = "black";
     ctx.fillText("Loading " + loaded, 8 * GU, 4.5 * GU);
+    t = old_time = performance.now();
     return;
   }
   t = performance.now();


### PR DESCRIPTION
Not doing this results in a potential buildup of unexecuted update loops
that will be executed all at once after loading is done.
