### PR TITLE
Change canvas clear strategy in bootstrap.js

### DIFF
--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -71,7 +71,7 @@ function loop() {
     dt -= MS_PER_FRAME;
   }
   /* clearing canvas */
-  canvas.width = canvas.width;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
   sm.render(ctx);
 
 

--- a/game/Character.js
+++ b/game/Character.js
@@ -300,6 +300,7 @@ Character.prototype.render = function(ctx, player_next, coeff, lightImg, darkImg
   var padding = GU * 0.5;
   ctx.fillStyle = 'white';
   ctx.textAlign = 'center';
+  ctx.textBaseline = 'bottom';
   ctx.fillText(name , 0, -2.1 * GU);
 
   ctx.fillStyle = 'white';


### PR DESCRIPTION
Canvas.clearRect is faster than canvas.width nowadays. This change means
that more care needs to be taken not to mutate canvas context state
across frames, since the context is no longer completely reset.
