### PR TITLE
Add chat commands to change game variables

### DIFF
--- a/game/Bullet.js
+++ b/game/Bullet.js
@@ -5,8 +5,10 @@ try {
   var Character = require('./../game/Character');
 }
 
+Bullet.speed = 0.3;
+Bullet.damage = 7;
+
 function Bullet() {
-  this.SPEED = 0.3;
   this.WEAPON_DISTANCE = 0.1;
 }
 
@@ -23,12 +25,16 @@ Bullet.prototype.init = function(x, y, dx, dy, team){
   this.team = team;
 };
 
+Bullet.prototype.getDamage = function(){
+  return Bullet.damage;
+}
+
 Bullet.prototype.fire = function(character, fire_dir_x, fire_dir_y){
   this.character = character;
   var x = character.x + (Character.BODY_RADIUS + this.WEAPON_DISTANCE) * fire_dir_x;
   var y = character.y + (Character.BODY_RADIUS +  this.WEAPON_DISTANCE) * fire_dir_y;
-  var dx = fire_dir_x * this.SPEED;
-  var dy = fire_dir_y * this.SPEED;
+  var dx = fire_dir_x * Bullet.speed;
+  var dy = fire_dir_y * Bullet.speed;
   this.init(x, y, dx, dy, character.team);
   return this;
 };

--- a/game/Character.js
+++ b/game/Character.js
@@ -5,7 +5,6 @@ try {
 }
 
 function Character(team, spawnPoint) {
-  this.breakingCoefficient = 0.025;
   this.accelerationCoefficient = 0.012;
   this.MAX_HP = 10;
   this.team = team;
@@ -18,7 +17,9 @@ function Character(team, spawnPoint) {
 
 Character.MAX_SHIELD_ARC = 0.2 * Math.PI;
 Character.OVERHEAT_THRESHOLD = 1.5;
+Character.heat_per_shot = 0.2;
 Character.BODY_RADIUS = 0.6;
+Character.breaking_coefficient = 0.025;
 
 Character.prototype.init = function(spawnPoint) {
   if (spawnPoint) {
@@ -79,7 +80,7 @@ Character.prototype.hit = function(bullet, soundsToPlay) {
     this.dx += bullet.dx;
     this.dy += bullet.dy;
 
-    this.hp --;
+    this.hp -= bullet.getDamage();
     if (this.hp <= 0){
       this.deaths++;
       if(bullet.character){
@@ -259,7 +260,7 @@ Character.prototype.applyFrictionForce = function() {
   var currentDirection = this.getCurrentDirection();
   var currentSpeed = Math.sqrt(Math.pow(this.dx, 2) + Math.pow(this.dy, 2));
   var activeShieldFactor = this.isShieldActive ? 2.2 : 1; // more friction while shield is active
-  var frictionScalar = - activeShieldFactor * this.breakingCoefficient * Math.pow(currentSpeed * 5 +.15, 2);
+  var frictionScalar = - activeShieldFactor * Character.breaking_coefficient * Math.pow(currentSpeed * 5 +.15, 2);
   var breakFx = frictionScalar * Math.cos(currentDirection);
   var breakFy = frictionScalar * Math.sin(currentDirection);
   this.dx += breakFx;

--- a/server/server.js
+++ b/server/server.js
@@ -36,6 +36,23 @@ var announce_timer = 0;
 /* used for triggering sound effects */
 var oldLightCapturePointCount = 0;
 var oldDarkCapturePointCount = 0;
+var commands = {
+  "!bspeed" : function(value){
+      Bullet.speed = value;
+  },
+  "!bdmg" : function(value){
+      Bullet.damage = value;
+  },
+  "!firecd" : function(value){
+      fireCooldownTime = value*60;
+  },
+  "!heatrate" : function(value){
+      Character.heat_per_shot = value;
+  },
+  "!friction" : function(value){
+      Character.breaking_coefficient = value;
+  },
+}
 
 reset_game();
 
@@ -63,6 +80,7 @@ wsServer.on('request', function(r) {
       connection.player.input = [false].concat(event.inputs);
     } else if (event.type == 'chat') {
       console.log((new Date()) + ' Chat: ' + connection.player.name + ': ' + event.message);
+      parseChatMessage(event.message);
       for(var i in clients) {
         if(!clients.hasOwnProperty(i)) {
           continue;
@@ -128,6 +146,16 @@ wsServer.on('request', function(r) {
 });
 
 
+function parseChatMessage(msg){
+  var msg_split = msg.split(" ");
+  var prefix = msg_split[0];
+  if(prefix in commands){
+    var value = parseFloat(msg_split[1]);
+    if(!isNaN(value)){
+      commands[prefix](msg_split[1]);
+    }
+  }
+}
 
 function loop() {
   time = getTime();
@@ -236,7 +264,7 @@ function update() {
           // fire
           bullets.push((new Bullet()).fire(character, fire_dir_x, fire_dir_y));
         }
-        character.weaponHeat += 0.2;
+        character.weaponHeat += Character.heat_per_shot;
         if (character.weaponHeat > Character.OVERHEAT_THRESHOLD) {
           character.overheated = true;
           character.weaponHeat = Character.OVERHEAT_THRESHOLD;


### PR DESCRIPTION
Now we can do live tweaking of game variables without server restart. (Thank god we don't have input prediction yet)

Supported commands are: 

Set bullet speed to 0.3 game units per tick:
`!bspeed 0.3`

Set bullet damage to 7 damage per hit (players have 10 hp)
`!bdmg 7`

Set firing cooldown to 0.5 seconds
`!firecd 0.5`

Set heatrate to 0.5 per shot (overheats at 1.5 for some reason)
`!heatrate 0.5`

And change the friction coefficient
`!friction 0.005`
